### PR TITLE
Add m2cgen for transpiling ML models into C code

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,8 @@ Table of content
 * [ARM Compute Library](https://developer.arm.com/technologies/compute-library) - Set of optimized functions for image processing, computer vision, and machine learning.
 * [uTensor](https://github.com/uTensor/uTensor) - AI inference library based on mbed (an RTOS for ARM chipsets) and TensorFlow.
 * [EmbededAI](https://github.com/boralt/EmbeddedAI) - A library that provides elements of AI to C++ applications.
-* [kann](https://github.com/attractivechaos/kann) - A lightweight C library for artificial neural networks
+* [kann](https://github.com/attractivechaos/kann) - A lightweight C library for artificial neural networks.
+* [m2cgen](https://github.com/BayesWitnesses/m2cgen) - A CLI tool which allows to transpile trained classic ML models into a native code of various programming languages with zero dependencies including C.
 
 ## Utilities
 


### PR DESCRIPTION
`m2cgen` is a lightweight library with command line interface which allows to transpile trained machine learning models into a native code of C programming language. Examples of generated C code can be found [here](https://github.com/BayesWitnesses/m2cgen/tree/master/generated_code_examples/c).