### PR TITLE
Adding estd mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,7 @@ Table of content
 * [apollo](https://github.com/ApolloAuto/apollo) - An open autonomous driving platform.
 * * [A Development Environment for ARM TrustZone with GlobalPlatform Support](https://www.eit.lth.se/sprapport.php?uid=793)
 * [A C++ template library for embedded applications](https://github.com/ETLCPP/etl)
+* [Embedded rework of C++ STL](https://github.com/malachi-iot/estdlib) - `basic_string`, `basic_ostream` etc. leaned way down.  Cross platform (including AVR).
 
 ## Embedded GUI Development
 * [Embedded Wizard](https://www.embedded-wizard.de/) - Sophisticated GUI for Your Embedded Platform


### PR DESCRIPTION
`estdlib` opens the door to `std`-like operations in embedded environments:

* Absolutely no: dynamic allocation, virtual methods, exceptions, rtti
* Familiar things like `basic_string`, `basic_ostream` etc.
* When possible, bring forward post c++11 things like `estd::expected` into c++11
* `estd::variadic` for when fold expressions aren't available