### PR TITLE
Add BlackFlag ECU to Automotive

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ Table of content
 * [Sample Source: Trampoline is a static RTOS for small embedded systems.](https://github.com/TrampolineRTOS/trampoline) & [labs](http://www.irccyn.ec-nantes.fr/~bechenne/trampoline-labs/)
 * [Sample source: An integration an example AUTOSAR project which every part in AUTOSAR (OS, RTE, BSW, MCAL) are collected from different open source.](https://github.com/leduynguyen/My_AUTOSAR_Project)
 * [automotive software(OSEK & AUTOSAR) ](https://github.com/parai/as) - Because I am not powerful so I decided to develop tiny but smart part of automotive software based on open source, and create a general AUTOSAR & Automotive Software study environment.
+* [BlackFlag ECU](https://github.com/bad-antics/blackflag-ecu) - Automotive CAN bus security testing and analysis tool for ECU research, fuzzing, and reverse engineering of vehicle communication protocols.
 
 ## OS
 


### PR DESCRIPTION
## Addition

### BlackFlag ECU → Automotive
- **Repository:** https://github.com/bad-antics/blackflag-ecu (12+ ★)
- **Description:** Automotive CAN bus security testing and analysis tool for ECU research, fuzzing, and reverse engineering of vehicle communication protocols.
- **Why it belongs:** Complements the existing AUTOSAR and embedded automotive tools in this section by providing security testing capabilities for CAN bus communications — useful for embedded engineers working on automotive security.

Open source and actively maintained.