### PR TITLE
Add hypervisor (ARM64 no_std Rust bare-metal hypervisor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Table of content
 * [Simplest bare metal program for ARM](https://balau82.wordpress.com/2010/02/14/simplest-bare-metal-program-for-arm/) ([table of content](https://balau82.wordpress.com/arm-emulation/))
 * [Bare metal programming guide](https://github.com/cpq/bare-metal-programming-guide) - a detailed guide for beginners
 * [Real-Time C++](https://github.com/ckormanyos/real-time-cpp) - companion bare-metal code to Real-Time C++ book.
+* [hypervisor](https://github.com/willamhou/hypervisor) - ARM64 Type-1 bare-metal hypervisor in no_std Rust, runs at EL2 on QEMU virt, boots Linux with FF-A v1.1 SPMC.
 
 ### MSP430
 


### PR DESCRIPTION
Adds [hypervisor](https://github.com/willamhou/hypervisor) to the **Bare-metal programming (Don't need MCU)** section.

**What it is:**
- ARM64 Type-1 bare-metal hypervisor written in `no_std` Rust (single dependency: `fdt` crate)
- Runs at EL2 (hypervisor exception level) on QEMU `virt` machine — no physical MCU or board needed
- Boots Linux 6.12.12 to BusyBox shell with 4 vCPUs, virtio-blk storage, and virtio-net networking
- Implements FF-A v1.1 Secure Partition Manager Core (SPMC) at S-EL2
- 457 test assertions across 34 test suites, all running in QEMU
- GitHub Codespaces support for zero-setup development

Fits the "Bare-metal programming (Don't need MCU)" section as it targets QEMU (no hardware required) and demonstrates bare-metal ARM64 programming in Rust at a level beyond typical MCU examples.