### PR TITLE
Add nn2 to Machine Learning & AI on MCU

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ Table of content
 * [EmbededAI](https://github.com/boralt/EmbeddedAI) - A library that provides elements of AI to C++ applications.
 * [kann](https://github.com/attractivechaos/kann) - A lightweight C library for artificial neural networks.
 * [m2cgen](https://github.com/BayesWitnesses/m2cgen) - A CLI tool which allows to transpile trained classic ML models into a native code of various programming languages with zero dependencies including C.
+* [nn2](https://github.com/facex-engine/facex/tree/master/nn2) - Tiny zero-dependency neural network inference engine in pure C with hand-written SIMD kernels (AVX-512 / AVX2 / NEON). Runs the FaceX face recognition stack on Apple Silicon, ARM SBCs and ESP32-P4. Apache 2.0.
 
 ## Utilities
 


### PR DESCRIPTION
Adds [nn2](https://github.com/facex-engine/facex/tree/master/nn2) to the Machine Learning & AI on MCU section.

Tiny zero-dependency neural network inference engine in pure C with hand-written SIMD kernels (AVX-512, AVX2, NEON). Around 4000 lines of C, builds with a free compiler, no Python or RTOS required.

It runs the FaceX face recognition stack on Apple Silicon, NXP iMX class ARM SBCs and on ESP32-P4 with the vendor SIMD extension. Apache 2.0.

Thanks for maintaining the list.