### PR TITLE
Add ForestHub.ai under Machine Learning & AI on MCU

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,7 @@ Table of content
 * [kann](https://github.com/attractivechaos/kann) - A lightweight C library for artificial neural networks.
 * [m2cgen](https://github.com/BayesWitnesses/m2cgen) - A CLI tool which allows to transpile trained classic ML models into a native code of various programming languages with zero dependencies including C.
 * [nn2](https://github.com/facex-engine/facex/tree/master/nn2) - Tiny zero-dependency neural network inference engine in pure C with hand-written SIMD kernels (AVX-512 / AVX2 / NEON). Runs the FaceX face recognition stack on Apple Silicon, ARM SBCs and ESP32-P4. Apache 2.0.
+* [ForestHub.ai](https://foresthub.ai) - Embedded & edge AI agent platform with codegen for ESP32/STM32.
 
 ## Utilities
 

--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ Table of content
 * [kann](https://github.com/attractivechaos/kann) - A lightweight C library for artificial neural networks.
 * [m2cgen](https://github.com/BayesWitnesses/m2cgen) - A CLI tool which allows to transpile trained classic ML models into a native code of various programming languages with zero dependencies including C.
 * [nn2](https://github.com/facex-engine/facex/tree/master/nn2) - Tiny zero-dependency neural network inference engine in pure C with hand-written SIMD kernels (AVX-512 / AVX2 / NEON). Runs the FaceX face recognition stack on Apple Silicon, ARM SBCs and ESP32-P4. Apache 2.0.
-* [ForestHub.ai](https://foresthub.ai) - Embedded & edge AI agent platform with codegen for ESP32/STM32.
+* [edge-agents (ForestHub)](https://github.com/ForestHubAI/edge-agents) - Open-source (AGPL-3.0) 30 MB AI agent runtime for edge devices. Offline by default; GPIO/UART/MQTT as first-class nodes; local SLMs alongside cloud LLMs. Runs on Raspberry Pi 5, Jetson Orin Nano, STM32MP25, ctrlX CORE.
 
 ## Utilities
 


### PR DESCRIPTION
## Summary

Adds one entry under **Machine Learning & AI on MCU** for [ForestHub.ai](https://foresthub.ai) — an embedded & edge AI agent platform with codegen targeting ESP32/STM32.

## Why this fits

Sits alongside existing entries like CMSIS-NN, uTensor and Embedded Learning Library — all targeting ML on microcontrollers — but ForestHub focuses on the agent layer (visual builder, generated embedded code, MQTT/HTTP delegation) on top of TinyML inference.

## Disclosure

I'm affiliated with ForestHub.ai. Happy to adjust the wording or omit. Thanks for maintaining the list.