### PR TITLE
Add Jumpstarter to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ Table of content
 
 ## Utilities
 
+* [Jumpstarter](https://github.com/jumpstarter-dev/jumpstarter) - Open source hardware-in-the-loop testing framework for automated testing on real and virtual embedded hardware with CI/CD integration.
 * [lm4tools](https://github.com/utzig/lm4tools)
 * [mspdebug](https://github.com/dlbeer/mspdebug) - Debugging tool for MSP430 MCUs
 * [pycs](https://github.com/deadsy/pycs) - Python Based ARM CoreSight Debug and Trace Tools


### PR DESCRIPTION
Add Jumpstarter, an open source hardware-in-the-loop testing framework for embedded systems. It supports automated testing on real and virtual hardware with CI/CD integration and distributed device management via Kubernetes.

https://github.com/jumpstarter-dev/jumpstarter