### PR TITLE
Add SiliconRig to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,7 @@ Table of content
 * [MemBrowse](https://membrowse.com) - Memory footprint tracking for ELF binaries with CLI and CI integration to monitor flash/RAM usage across commits.
 * [aem-modbus-simulator](https://github.com/leaberg69/aem-modbus-simulator) - Open-source Python Modbus RTU/TCP slave simulator emulating an industrial DC voltage monitor (147 holding registers, 6 baudrates). Lets SCADA/PLC firmware engineers test Modbus integration in CI pipelines without physical hardware on the bench.
 * [memprobe.dev](https://memprobe.dev) - ELF firmware analysis as a web app, CLI, and GitHub Action. Break down flash and RAM usage by section, file, library, and symbol, compare builds, track project history and memory growth over time, and set CI size budgets.
+* [SiliconRig](https://siliconrig.dev) - Cloud-hosted embedded boards (ESP32-S3, STM32, RP2350) for remote flashing, serial console, and hardware-in-the-loop testing in CI. Open-source CLI, Python SDK, and GitHub Action.
 
 ## Tips & tricks
 


### PR DESCRIPTION
Disclosure: I build this. SiliconRig is a hosted board farm - real ESP32-S3/STM32/RP2350 boards you can flash and test from CI - in the same space as the Jumpstarter entry already in Utilities. The CLI, Python SDK, and GitHub Action are open source (github.com/siliconrig). Happy to adjust wording or placement, or close if hosted services are out of scope.