### PR TITLE
Add EmbedEval to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,7 @@ Table of content
 
 * [Jumpstarter](https://github.com/jumpstarter-dev/jumpstarter) - Open source hardware-in-the-loop testing framework for automated testing on real and virtual embedded hardware with CI/CD integration.
 * [lm4tools](https://github.com/utzig/lm4tools)
+* [EmbedEval](https://github.com/Ecro/embedeval) - Benchmark that measures how well LLMs write embedded firmware. 233 cases across Zephyr, ESP-IDF, STM32 HAL, FreeRTOS, Linux drivers and Yocto, verified through static checks, SDK compilation, runtime execution and mutation testing.
 * [mspdebug](https://github.com/dlbeer/mspdebug) - Debugging tool for MSP430 MCUs
 * [pycs](https://github.com/deadsy/pycs) - Python Based ARM CoreSight Debug and Trace Tools
 * [NaiveSystems Analyze](https://github.com/naivesystems/analyze) - Static Analysis Tool for Code Security and Compliance


### PR DESCRIPTION
[EmbedEval](https://github.com/Ecro/embedeval) is an open-source benchmark that measures how well LLMs write embedded firmware.

**Disclosure: I am the author.**

Every general coding benchmark (HumanEval, SWE-bench, Aider Polyglot) stops at application code. On the embedded side, EmbedAgent (ICSE'26) covers Arduino, MicroPython and ESP-IDF, but Zephyr, STM32 HAL, FreeRTOS, Linux kernel drivers and Yocto were unmeasured. EmbedEval covers those.

What it does:

- 233 cases (185 public, 48 held out of training data) across 23 categories and 6 platforms
- 5-layer evaluation: static checks, Docker SDK compile, `native_sim`/QEMU runtime, domain heuristics, and mutation testing that validates the checks themselves
- Results published with n=3 runs and Wilson 95% confidence intervals, not single-shot scores

The practical finding so far: pass rates collapse in exactly the categories where embedded engineers already do their careful reviewing, namely DMA, ISR and threading.

- License: Apache-2.0
- Methodology: https://github.com/Ecro/embedeval/blob/main/docs/METHODOLOGY.md
- Leaderboard: https://huggingface.co/spaces/ecro/embedeval

Placed under Utilities next to Jumpstarter, since both are testing tooling rather than a library you link against.