### PR TITLE
Add EdgeLog to Tech blogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ Table of content
 * [A Guide to Undefined Behavior in C and C++](https://blog.regehr.org/archives/213)
 * [Software Engineering Takeaways](https://blog.regehr.org/archives/1594)
 * [Embedsys weekly newsletter](https://embedsysweekly.com/)
+* [EdgeLog](https://edgelog.dev/) - Embedded and edge AI engineering notes, with measurements from running LLMs and agents against real hardware.
 
 ## FAQ_Embedded
 


### PR DESCRIPTION
[EdgeLog](https://edgelog.dev/) is an engineering notebook about embedded and edge AI, written from measurements on real hardware rather than tutorials.

**Disclosure: I write it.**

The angle that is not already covered by the entries in this section: what actually happens when you point LLMs and coding agents at firmware. Recent posts publish the numbers rather than opinions, for example a 233-case benchmark of LLM-generated firmware across Zephyr, ESP-IDF and STM32 HAL, where pass rates hold up on application logic and fall apart on DMA, ISR and threading.

Other topics: Yocto and BSP work, the EU Cyber Resilience Act as it lands on embedded teams, on-device inference, and offline RAG over datasheets.

- 33 posts, English with Korean translations
- Every post states its hardware, toolchain versions and measurement method
- Supporting open-source work: [EmbedEval](https://github.com/Ecro/embedeval) (Apache-2.0) and [harness-maker](https://github.com/Ecro/harness-maker)

Placed at the bottom of Tech blogs, alongside the Embedsys weekly entry, since both are ongoing publications rather than single articles.