### PR TITLE
Add stm32-async-1wire — non-blocking 1-Wire master for STM32 (F1/F0/G0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Table of content
 * [stm32-rf-scanner](https://github.com/gemesa/stm32-rf-scanner) - STM32 and nRF24L01+ based 2.4GHz RF scanner
 * [stm32-dc-dc](https://github.com/gemesa/stm32-dc-dc) - STM32 based DC-DC converter
 * [rustlink](https://github.com/gemesa/rustlink) - small set of Rust tools to program STM32 devices
-* [stm32-async-1wire](https://github.com/a5021/stm32-async-1wire) - Non-blocking, register-level 1-Wire master for STM32 (DS18B20 temperature driver on top). Hardware-timed (TIM1+DMA, DMAMUX on G0), interrupt-free, RTOS-agnostic; header-only backends for STM32F1/F0/G0; hardware-validated on Blue Pill (F103) and STM32G031.
+* [stm32-async-1wire](https://github.com/a5021/stm32-async-1wire) - Non-blocking, register-level 1-Wire master for STM32 (DS18B20 temperature driver on top). Hardware-timed (TIM1+DMA, DMAMUX on G0), interrupt-free, RTOS-agnostic; header-only backends for STM32F1/F0/G0; hardware-validated on Blue Pill (F103) and STM32G031; strong-pull-up parasite powering; released v1.6.1.
 
 ### STM32F7
 * [STM32F7 Series](https://www.st.com/en/microcontrollers/stm32f7-series.html?querycriteria=productId=SS1858)

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Table of content
 * [stm32-rf-scanner](https://github.com/gemesa/stm32-rf-scanner) - STM32 and nRF24L01+ based 2.4GHz RF scanner
 * [stm32-dc-dc](https://github.com/gemesa/stm32-dc-dc) - STM32 based DC-DC converter
 * [rustlink](https://github.com/gemesa/rustlink) - small set of Rust tools to program STM32 devices
+* [non-blocking-ds18B20-driver-for-stm32f103c8t6](https://github.com/a5021/non-blocking-ds18B20-driver-for-stm32f103c8t6) - Bare-metal, register-level DS18B20 (1-Wire) temperature driver for STM32 (STM32F103C8T6); hardware-timed (TIM1+DMA), non-blocking, interrupt-free, RTOS-agnostic, minimal CPU overhead.
 
 ### STM32F7
 * [STM32F7 Series](https://www.st.com/en/microcontrollers/stm32f7-series.html?querycriteria=productId=SS1858)

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Table of content
 * [stm32-rf-scanner](https://github.com/gemesa/stm32-rf-scanner) - STM32 and nRF24L01+ based 2.4GHz RF scanner
 * [stm32-dc-dc](https://github.com/gemesa/stm32-dc-dc) - STM32 based DC-DC converter
 * [rustlink](https://github.com/gemesa/rustlink) - small set of Rust tools to program STM32 devices
-* [non-blocking-ds18B20-driver-for-stm32f103c8t6](https://github.com/a5021/non-blocking-ds18B20-driver-for-stm32f103c8t6) - Bare-metal, register-level DS18B20 (1-Wire) temperature driver for STM32 (STM32F103C8T6); hardware-timed (TIM1+DMA), non-blocking, interrupt-free, RTOS-agnostic, minimal CPU overhead.
+* [stm32-async-1wire](https://github.com/a5021/stm32-async-1wire) - Non-blocking, register-level 1-Wire master for STM32 (DS18B20 temperature driver on top). Hardware-timed (TIM1+DMA, DMAMUX on G0), interrupt-free, RTOS-agnostic; header-only backends for STM32F1/F0/G0; hardware-validated on Blue Pill (F103) and STM32G031.
 
 ### STM32F7
 * [STM32F7 Series](https://www.st.com/en/microcontrollers/stm32f7-series.html?querycriteria=productId=SS1858)


### PR DESCRIPTION
Adding [stm32-async-1wire](https://github.com/a5021/stm32-async-1wire) to the STM32 section.

- Non-blocking, register-level **1-Wire master for STM32**, with a DS18B20 temperature driver on top.
- Hardware-timed (TIM1 + DMA, DMAMUX on G0), fully polled — **no NVIC interrupts, interrupt-free, RTOS-agnostic**.
- Header-only backends for **STM32F1 / STM32F0 / STM32G0**, selected at build time via `make OW_TARGET=...`.
- **Hardware-validated** on Blue Pill (STM32F103) and STM32G031F6P6; automatic parasite-power detection.
- MCU-independent core (`src/onewire.c` + `src/ds18b20.c`) over a small `ow_port_*` port interface.

Single-task safe by design; serialize with a mutex if calling from multiple RTOS tasks.

---
Recent updates since submission: STM32F0 and STM32G0 backends added (DMAMUX on G0), G0 hardware-validated on STM32G031F6P6, automatic parasite-power detection, strong-pull-up refinement for robust parasite powering, and tagged releases up to **v1.6.1**.