### PR TITLE
Add EA-SKILL: embedded AI dev toolset for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Table of content
 * [Embedded Interview Questions](https://docs.google.com/document/d/18HMyd-lFu1hWiixFLS2Pc7-SgyzDDqitzXbfAnUVeBE/mobilebasic)
 * [Interview Questions Archive by Company](https://docs.google.com/document/d/1uW030FMfBxKLxXz-eIwyzlMJdERN5DMEwtUnJMYsF-g/edit?usp=sharing)
 * [Coding Interview University](https://github.com/jwasham/coding-interview-university) - A complete computer science study plan to become a software engineer.
+* [EA-SKILL](https://github.com/jzl-maker/EA-SKILL)
 
 ## Embedded Software Skill
 


### PR DESCRIPTION
This PR adds [EA-SKILL](https://github.com/jzl-maker/EA-SKILL) to the list.

**What it is**: An embedded-dev AI toolset for Claude Code — context-aware
`/ea init`, feature planning, unit tests, build/flash/serial/J-Link debug,
SVD register maps, logic analyzer/oscilloscope integration, and a full verify
loop (compile → flash → J-Link run → serial → protected-area audit).

**Why it fits this list**:
- Open source under MIT, actively maintained
- Works with Keil / OpenOCD / J-Link workflows
- Unique safety guardrail: AI is forbidden from modifying protected files
  (startup_*.s, vector tables, linker scripts) without explicit `/ea approve`

I've followed the contribution guidelines. Thanks for maintaining this list!
