### PR TITLE
Add flashgate to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,7 @@ Table of content
 ## Utilities
 
 * [Jumpstarter](https://github.com/jumpstarter-dev/jumpstarter) - Open source hardware-in-the-loop testing framework for automated testing on real and virtual embedded hardware with CI/CD integration.
+* [flashgate](https://github.com/Lion-1209/flashgate) - Hardware-in-the-loop verification gate for AI coding agents: build, flash over ST-Link, then assert the board's boot banner, SWD RAM signature and console-probe register readbacks before "done" is accepted. Ships as a Claude Code plugin (Stop hook + MCP server).
 * [lm4tools](https://github.com/utzig/lm4tools)
 * [EmbedEval](https://github.com/Ecro/embedeval) - Benchmark that measures how well LLMs write embedded firmware. 233 cases across Zephyr, ESP-IDF, STM32 HAL, FreeRTOS, Linux drivers and Yocto, verified through static checks, SDK compilation, runtime execution and mutation testing.
 * [mspdebug](https://github.com/dlbeer/mspdebug) - Debugging tool for MSP430 MCUs


### PR DESCRIPTION
Adds [flashgate](https://github.com/Lion-1209/flashgate) to the Utilities section, next to the other hardware-in-the-loop entries (Jumpstarter, SiliconRig, Scrutiny).

flashgate is a hardware-in-the-loop verification gate for AI coding agents working on embedded firmware: when the agent claims "done", it rebuilds, flashes over ST-Link, and requires the board itself to prove which build is running (UART boot banner carrying the git sha, or a 64-byte SWD RAM signature), plus optional console probes that assert on register readbacks (e.g. timer CCR). It ships as a Claude Code plugin (Stop hook + MCP server) and works with any STM32 via STM32CubeProgrammer.

Disclosure: I am the author. MIT-licensed, open source, with a buildable example for the ALIENTEK Apollo STM32H743.